### PR TITLE
Replace scancode by up-to-date keycode

### DIFF
--- a/addons/ControlsRemap/ControlsRemap.gd
+++ b/addons/ControlsRemap/ControlsRemap.gd
@@ -117,7 +117,7 @@ func find_duplicates() -> Array[String]:
 				
 				var key2 := get_action_key(action2)
 				if key2:
-					if key1.scancode == key2.scancode:
+					if key1.keycode == key2.keycode:
 						dupes.append(action)
 						break
 	


### PR DESCRIPTION
InputEventKey does not use scancode anymore.
This was probably a left over from an ancient version of Godot.

https://docs.godotengine.org/en/stable/classes/class_inputeventkey.html